### PR TITLE
Document how to add write permissions to repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,26 @@
 ✨ Live site: [compass.jupyterbook.org](https://jupyterbook.org).
 📚 Source files: [`docs/`](docs/)
 
+## Build the documentation locally
+
+This site is built with [the MyST Document Engine](https://mystmd.org).
+To build it locally:
+
+1. Install MyST from PyPI:
+
+   ```
+   pip install mystmd
+   ```
+2. Clone the repository and change into the `docs/` folder:
+
+   ```
+   git clone https://github.com/jupyter-book/team-compass
+   cd team-compass/docs
+   ```
+3. Start the MyST server:
+
+   ```
+   myst start
+   ```
+
+For more information on building sites with MyST, see [the MyST Guide](https://mystmd.org/guide).

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -16,6 +16,7 @@ project:
   toc:
     - file: index.md
     - file: team.md
+    - file: tips.md
     - file: contribute.md
     - file: code-of-conduct.md
 site:

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -1,0 +1,19 @@
+# Development tips
+
+## Enable publishing with GitHub Actions in new repositories
+
+By default, GitHub disables **`write`** privileges in any repository in the [`jupyter-book` organization](https://github.com/jupyter-book).
+This prevents repositories from being able to publish new releases from GitHub Actions.
+
+To enable write access in GitHub Actions, add the following to the relevant GitHub Action in the repository.
+
+```{code-block} yaml
+:filename: .github/publish.yml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+For more information, see [the GitHub Actions documentation](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#defining-access-for-the-github_token-permissions).
+
+For examples of this pattern in use in the Jupyter Book organization, see [this GitHub search query of using this configuration](https://github.com/search?q=org:jupyter-book+%22contents:+write%22+language:YAML&type=code).


### PR DESCRIPTION
This adds short documentation on how to add write permissions to new repositories, as a quick reference for folks that might be confused by this in the future.