### PR TITLE
Add governance, mailing list, and MEP links

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -23,3 +23,20 @@ Our Code of Conduct defines acceptable and unacceptable behavior for any individ
 It also defines mechanisms for reporting violations and processes for dealing with them.
 
 See [](code-of-conduct.md) for more information.
+
+### MyST specification
+
+MyST is a special project of the Jupyter Book community, here are two sources of truth:
+
+:::{list-table}
+:header-rows: 1
+- * Name
+  * Documentation
+  * Repository
+- * **MyST document structure and markdown standard**
+  * [mystmd.org/spec](https://mystmd.org/spec)
+  * [jupyter-book/myst-spec](https://github.com/jupyter-book/myst-spec)
+- * **MyST enhancement proposals**
+  * [mep.mystmd.org](https://mep.mystmd.org/en/latest/)
+  * [jupyter-book/myst-enhancement-proposals](https://github.com/jupyter-book/myst-enhancement-proposals)
+:::

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -16,6 +16,7 @@ project:
   toc:
     - file: index.md
     - file: team.md
+    - file: governance.md
     - file: contribute.md
     - file: code-of-conduct.md
 site:

--- a/docs/team.md
+++ b/docs/team.md
@@ -6,6 +6,18 @@ title: Team
 
 ## Steering council
 
+The steering council are the primary stewards of the Jupyter Book project and community.
+They set organizational policy and strategy, make decisions when we are at an impasse, and delegate power to others in the organization.
+
+### Mailing list
+
+The Steering Council uses a **Mailing List** for its internal and external communication.
+Anybody may message this list to get in touch with the Steering Council as a whole.
+
+The Steering Council Mailing List is: [**`jupyter-book-council@googlegroups.com`**](mailto:jupyter-book-council@googlegroups.com).
+
+### Members
+
 ```{grid} 3
 :::{card} Chris Holdgraf
 :link: https://github.com/choldgraf


### PR DESCRIPTION
This adds a page to (roughly) describe the current governance and sources of truth for Jupyter Book, as well as a mailing list for the steerco. It includes links to our myst enhancement proposals docs.