### PR TITLE
Add Angus as ssc rep

### DIFF
--- a/docs/team.md
+++ b/docs/team.md
@@ -50,6 +50,21 @@ Our core team consists of the following people (in alphabetical order).
 - [`@rowanc1`](https://github.com/rowanc1)
 - [`@stevejpurves`](https://github.com/stevejpurves)
 
+## Software Steering Council Representative
+
+Our {abbr}`SSC (Software Steering Council)` representative is [`@agoose77`](https://github.com/agoose77).
+
+The checkpoint to choose a new SSC representative is **October 1st, 2025**.
+
+:::{note} Our guidelines around SSC representative
+:class: dropdown
+
+The Jupyter Project asks each sub-project to delegate one team member to serve as representative to the [Software Steering Council](https://jupyter.org/governance/software_steering_council.html).
+
+We plan for this to be a role that rotates through the team, with a roughly one-year cycle.
+It can be any of the [core team members](#core-team).
+:::
+
 ## Organizational status
 
 The Jupyter Book community is a sub-project of [the Jupyter Project](https://jupyter.org).


### PR DESCRIPTION
This designates @agoose77 as the SSC representative for Jupyter Book, and defines the guidelines we follow for term limits for this role.

We've discussed this via a few e-mail and Discourse threads, so this is just making the decision official. I'll ping @rowanc1 and @gregcaporaso for review but plan to merge this in a week if they don't first unless there are objections.

- closes #5 