### PR TITLE
Use YAML file for people

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #.idea/
 
 /_build/
+package-lock.json
+node_modules

--- a/docs/data/team.yml
+++ b/docs/data/team.yml
@@ -1,0 +1,28 @@
+# Listed in alphabetical order, beginning with the Steering Council
+# Steering Council
+- name: Chris Holdgraf
+  github: choldgraf
+  team: Steering Council
+  affiliation: 2i2c
+- name: Greg Caporaso
+  github: gregcaporaso
+  team: Steering Council
+  affiliation: Northern Arizona University
+- name: Rowan Cockett
+  github: rowanc1
+  team: Steering Council
+  affiliation: CurveNote
+
+# Core Team
+- name: Angus Hollands
+  github: agoose77
+  team: Core Team
+  affiliation: 2i2c
+- name: Frank W Koch
+  github: fwkoch
+  team: Core Team
+  affiliation: CurveNote
+- name: Steve Purves
+  github: stevejpurves
+  team: Core Team
+  affiliation: CurveNote

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -15,6 +15,8 @@ project:
   license: CC0-1.0
   references:
     jupyter_governance: https://jupyter.org/governance/
+  plugins:
+    - src/team.mjs
   toc:
     - file: index.md
     - file: team.md

--- a/docs/src/team.mjs
+++ b/docs/src/team.mjs
@@ -1,0 +1,39 @@
+import yaml from "js-yaml";
+import fs from "fs";
+
+// Read and parse team data
+const teamData = yaml.load(fs.readFileSync("data/team.yml", "utf8"));
+const teamDirective = {
+  name: "team",
+  doc: "Display members of a team!",
+  arg: { type: String, doc: "The team name.", required: true },
+  run(data, vfile, ctx) {
+    const team = data.arg;
+    var cards = [];
+    teamData.forEach(ii => {
+      if (ii["team"] === team) {
+        cards.push(`
+:::{card} ${ii["name"]}
+:link: https://github.com/${ii["github"]}
+:footer: **Affiliation:** ${ii['affiliation']}
+![${ii["name"]} avatar](https://github.com/${ii["github"]}.png)
+:::`)
+      }
+    });
+    if (cards.length === 0) {
+      throw new Error(`Team ${team} not found.`);
+    }
+    const grid = ctx.parseMyst(`
+::::{grid} 3
+${cards.join("\n")}
+::::`).children[0];
+    return [grid];
+  },
+};
+
+const plugin = {
+  name: "Compass team plugins",
+  directives: [teamDirective],
+};
+
+export default plugin;

--- a/docs/team.md
+++ b/docs/team.md
@@ -18,24 +18,7 @@ The Steering Council Mailing List is: [**`jupyter-book-council@googlegroups.com`
 
 ### Members
 
-```{grid} 3
-:::{card} Chris Holdgraf
-:link: https://github.com/choldgraf
-![Rowan avatar](https://github.com/choldgraf.png)
-Affiliation: 2i2c
-:::
-
-:::{card} Greg Caporaso
-:link: https://github.com/gregcaporaso
-![Rowan avatar](https://github.com/gregcaporaso.png)
-Affiliation: Northern Arizona University
-:::
-
-:::{card} Rowan Cockett
-:link: https://github.com/rowanc1
-![Rowan avatar](https://github.com/rowanc1.png)
-Affiliation: Curvenote
-:::
+```{team} Steering Council
 ```
 
 (core-team)=
@@ -44,11 +27,8 @@ Affiliation: Curvenote
 
 Our core team consists of the following people (in alphabetical order).
 
-- [`@agoose77`](https://github.com/agoose77)
-- [`@choldgraf`](https://github.com/choldgraf)
-- [`@fwkoch`](https://github.com/fwkoch)
-- [`@rowanc1`](https://github.com/rowanc1)
-- [`@stevejpurves`](https://github.com/stevejpurves)
+:::{team} Core Team
+:::
 
 ## Software Steering Council Representative
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "jupyter-book-team-compass",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/jupyter-book/team-compass.git"
+  },
+  "devDependencies": {
+      "js-yaml": "^4.1.0",
+      "myst-cli": "^1.3.18"
+  },
+  "engines": {
+      "npm": ">=10.7.0",
+      "node": ">=18.0.0"
+  },
+  "packageManager": "npm@10.7.0"
+}


### PR DESCRIPTION
This is another experiment as part of me trying to improve the plugin documentation. This adds a plugin to our compass that will auto-generate team member cards from a YAML file that defines the team members, affiliations, etc. It doesn't change any of the content, only adds the logic to generate the cards.

Is it somewhat excessive? Yes. Yes it is. But also pretty nifty that you can create plugins relatively quickly!