### PR TITLE
Add more prominent contributor information

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,12 +1,51 @@
-# Join the community
+# Contribute and join
 
-## Where do conversations happen?
+We're an open source community that welcomes contributions from others.
+Here are a few resources to help you get started interacting with our team and community, and making contributions to our projects.
 
-[The MyST Discord](https://discord.mystmd.org) is for general chat in the Jupyter Book and MyST community.
+## Is my contribution welcome?
 
-[The mystmd discussions board](https://github.com/jupyter-book/mystmd/discussions) has general conversation about [the MyST Markdown engine](https://mystmd.org).
+Absolutely! We welcome contribution from anyone, and want others to become contributors, maintainers, and leaders of this project. Please be patient - we also rely on volunteer labor, so we aren't always as responsive as we'd like to be. We promise to do our best!
 
-## How can I join the team meetings?
+## Where to talk
+
+::::{grid} 2
+:::{card} Contributor and user Discord 💬
+:link: https://discord.mystmd.org
+For general chat in the Jupyter Book and MyST community
++++
+Click to visit the Discord
+:::
+:::{card} MyST Discussions Board 💬
+:link: https://github.com/jupyter-book/mystmd/discussions
+For general conversation about the MyST Markdown engine.
++++
+Click to visit the Discussion Forum
+:::
+::::
+
+## Where to learn
+
+::::{grid} 2
+:::{card} The `mystmd` contributor guide 📚
+:link: https://mystmd.org/guide/contributing
+A getting-started page to point you in the right direction for contributions.
++++
+Click to visit the `mystmd` contributor guide
+:::
+:::{card} The `mystmd` developer guide 📚
+:link: https://mystmd.org/guide/developer
+A guide to making technical contributions to the MyST Document Engine stack.
++++
+Click to visit the `mystmd` contributor guide
+:::
+::::
+
+## Events and meetings
+
+### Monthly collaboration cafes
+
+Collaboration cafes are a way for members of the Jupyter Book community to remotely get together to share what they've been up to, have discussions, and work together.
 
 The Jupyter Book team is piloting an [experiment to join the JupyterHub Team Collaboaration Cafes][expt]. These are open to anyone, and are a way to discuss and work together across these projects.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,9 @@ title: The Jupyter Book Team Compass
 This documentation serves as the **Source of Truth** (SoT) for the Jupyter Book community policy and practices.
 It also aims to provide resources that facilitate contribution and coordination among team members.
 
-:::{note} Work in progress!
-Jupyter Book was recently [incorporated as a Jupyter sub-project](https://github.com/jupyter/enhancement-proposals/pull/123).
-
-It is in its infancy, and this team compass will change rapidly as we set up our ways of working and governance.
+:::{card} Want to contribute? Start here! ✨
+:link: contribute.md
+Our Team Compass is a way for others to understand our practices so that they can more effectively contribute. Click here to get started contributing.
 :::
 
 ## Goals of the Team Compass

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -1,5 +1,9 @@
 # Development tips
 
+:::{seealso} See the `mystmd` developer guide
+[Our `mystmd` Developer guide](https://mystmd.org/guide/developer) has a lot more information about contributing to the MyST Document Engine stack.
+:::
+
 ## Enable publishing with GitHub Actions in new repositories
 
 By default, GitHub disables **`write`** privileges in any repository in the [`jupyter-book` organization](https://github.com/jupyter-book).


### PR DESCRIPTION
In a conversation with @mfisher87 , I got some valuable feedback that it wasn't obvious whether the team compass was just for the maintainers of the core team, or if it was for everybody. We brainstormed a couple of things that could make it more inviting, and this PR implements them. It also takes a bit of inspiration from the [Rust community page](https://rust-lang.org/community).

This doesn't change any of our policies / practices, just makes information more clear. So I'll plan to merge in a day or so if I don't get a review and if there aren't objections. That said it'd be great if @mfisher87 had a moment to suggest whether this is a significant improvement!