### PR TITLE
Add team practices doc and document merge commit practices

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -23,6 +23,7 @@ project:
     - file: index.md
     - file: team.md
     - file: governance.md
+    - file: practices.md
     - file: tips.md
     - file: contribute.md
     - file: code-of-conduct.md

--- a/docs/practices.md
+++ b/docs/practices.md
@@ -1,5 +1,8 @@
 # Team practices
 
+These are team practices that we try to follow across all repositories of `jupyter-book`.
+They are not _strictly_ enforced, but we ask that you prioritize following them, and provide a clear rationale if you don't intend to.
+
 ## When merging PRs, use squash commits
 
 When you merge a pull request, **use Squash Commits** before merging.

--- a/docs/practices.md
+++ b/docs/practices.md
@@ -1,0 +1,10 @@
+# Team practices
+
+## When merging PRs, use squash commits
+
+When you merge a pull request, **use Squash Commits** before merging.
+
+:::{note} Have a rationale if you don't want to follow this practice
+If you _really want_ to use a Merge Commit, that's OK, but you should have a strong reason for why it's better to break with team guidelines before doing so.
+For example, it is sometimes useful to use Merge Commits for certain bot or CI/CD workflows.
+:::


### PR DESCRIPTION
This documents an org-wide team practice of using squash commits, and adds a page on our team practices where we can track these kinds of cross-project guidelines.