### PR TITLE
Add Kirstie to team

### DIFF
--- a/docs/data/team.yml
+++ b/docs/data/team.yml
@@ -11,7 +11,7 @@
 - name: Rowan Cockett
   github: rowanc1
   team: Steering Council
-  affiliation: CurveNote
+  affiliation: Curvenote
 
 # Core Team
 - name: Angus Hollands


### PR DESCRIPTION
This adds @kirstiejane to the Jupyter Book team. We've discussed this with the team already, and @kirstiejane has accepted, so this is just documenting the decision! Kirstie, I'm excited for all of the leadership and collaboration you've brought, and will continue to bring, to this project!