### PR TITLE
Add hackmd and move meeting details to jupyterbook.org

### DIFF
--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -88,3 +88,8 @@ To do so, follow these steps:
 5. Give them `MyST Admin` role.
 
 That's it!
+
+## Hackmd
+
+We have a [HackMD team](https://hackmd.io/team/jupyterbook) for sharing notes from meetings and design documents.
+Any [core team](./team.md) member should be added this team.

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,4 +1,4 @@
 (policy:coc)=
 # Code of Conduct
 
-The Jupyter Book community follows the [Project Jupyter Code of Conduct](xref:jupyter_governance#conduct/code_of_conduct).
+The Jupyter Book community follows the [Project Jupyter Code of Conduct](xref:jupyter_governance/conduct/code_of_conduct).

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -50,35 +50,18 @@ Click to visit the `mystmd` contributor guide
 (events)=
 ## Events and meetings
 
-(team-calendar)=
-
-The [Jupyter Book Calendar](https://calendar.google.com/calendar/u/4?cid=Y184YWIxNzY1YjY1ODY3NDVkOGI3NWU5MmJkYzdjYTZlNDZjYWExMmE1ZjhkOTUwZDVmNzNmMzI2Zjk3NjE0NGQ3QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) has a list of all Jupyter Book team meetings.
-Here it is:
-
-::::{figure}
-:label: collab-cafe-calendar
-:::{iframe} https://calendar.google.com/calendar/embed?src=c_8ab1765b6586745d8b75e92bdc7ca6e46caa12a5f8d950d5f73f326f976144d7%40group.calendar.google.com&ctz=America%2FLos_Angeles
-:::
-
-The meeting schedule for Jupyter Book Collaboration Cafes
-::::
+See [](org:#team-calendar).
 
 ### Monthly collaboration cafes
 
-Collaboration cafes are a way for any member of the Jupyter Book community to remotely get together to share what they've been up to, have discussions, and work together. You are welcome to join as long as you're interested in Jupyter Book!
+See [](xref:org#collaboration-cafe)
 
-See [the Jupyter Book Collaboration Cafe notes](https://hackmd.io/@jupyter-book/collaboration-cafe) for more details and meeting notes. 
+### Working meetings
 
-:::{seealso} Facilitator checklist
-See [](./meetings/facilitator-checklist.md) for instructions on how to facilitate this meeting. We encourage anyone who is willing to serve in this role.
-:::
-
-:::{note} This is an experiment!
-This is an experiment in opening up our team practices. [Here's a blog post explaining our goals][expt]. We'd love feedback on how we can improve these meetings in a sustainable way.
-:::
+See [](xref:org#working-sessions)
 
 ### Jupyter-wide events
 
-There are also many other events in the Jupyter ecosystem! See the [Jupyter Community events page](https://jupyter.org/community) for events across the Jupyter community.
+See [](xref:org#jupyter-events)
 
 [expt]: xref:blog/posts/2025-04-09-new-community-meeting

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -1,10 +1,10 @@
 # See docs at: https://mystmd.org/guide/frontmatter
 version: 1
 extends:
-  - https://raw.githubusercontent.com/jupyter-book/jupyter-book/refs/heads/main/docs/_site/site.yml
+  - https://raw.githubusercontent.com/jupyter-book/jupyterbook.org/refs/heads/main/docs/_site/site.yml
 project:
   id: 1ed3cb19-aaad-4cbf-86bf-57359c2e474b
-  title: "Jupyter Book: Team Compass"
+  title: "Team Compass"
   description: Team compass and documentation about governance for the Jupyter Book and MyST Markdown communities.
   keywords:
     - Jupyter
@@ -15,8 +15,9 @@ project:
   license: CC0-1.0
   references:
     jupyter_governance: https://jupyter.org/governance/
-    blog: https://blog.jupyterbook.org/
+    blog: https://jupyterbook.org/blog
     mep: https://mep.mystmd.org/
+    org: https://jupyterbook.org/
   plugins:
     - src/team.mjs
   toc:
@@ -33,6 +34,3 @@ project:
       - title: "2025"
         pattern: "meetings/2025/*.md"
       - file: meetings/facilitator-checklist.md
-site:
-  options:
-    logo_text: Team Compass


### PR DESCRIPTION
This:

- documents our hackmd
- removes some content because it's duplicated at jupyterbook.org
- updates the header to use the jupyterbook.org header